### PR TITLE
Fix bit.ly link

### DIFF
--- a/EmberConf-2015.markdown
+++ b/EmberConf-2015.markdown
@@ -216,7 +216,7 @@ Luke Melia | [@lukemelia](https://twitter.com/@lukemelia) | [Yapp](https://www.y
 
 ### Ambitious UX for Ambitious Apps
 
-Lauren Tan | [@sugarpirate_](https://twitter.com/@sugarpirate_) | [Homely](http://www.homely.com.au) | [Slides](bit.ly/sugarpirate)
+Lauren Tan | [@sugarpirate_](https://twitter.com/@sugarpirate_) | [Homely](http://www.homely.com.au) | [Slides](http://bit.ly/sugarpirate)
 
 Self-taught designer, then self-taught developer.
 


### PR DESCRIPTION
Add http to URL to prevent GitHub Flavored Markdown rendering link relative.